### PR TITLE
add sample magic and liturgy

### DIFF
--- a/Leif/DSA_Liturgy.spl
+++ b/Leif/DSA_Liturgy.spl
@@ -1,0 +1,125 @@
+{
+	"type": "spell_list",
+	"version": 4,
+	"rows": [
+		{
+			"id": "92d6cea5-c917-4e40-b0c4-c0a9f3060fe6",
+			"type": "spell",
+			"name": "Grabsegen",
+			"reference": "LL79",
+			"tags": [
+				"Liturgy"
+			],
+			"difficulty": "wb/e",
+			"college": [
+				"Zwölfgötter",
+				"H'Ranga"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "5 (2 if Primary)",
+			"casting_time": "1 SR",
+			"duration": "Instant",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Religious Rank"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Religion*"
+						},
+						"level": {
+							"compare": "at_least"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Clerical Investment"
+						},
+						"level": {
+							"compare": "at_least"
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "9fd739f9-eb93-413a-a4e7-c7331baf2fb2",
+			"type": "spell",
+			"name": "Objektweihe",
+			"reference": "LL224",
+			"tags": [
+				"Liturgy"
+			],
+			"difficulty": "wb/h",
+			"college": [
+				"Universell"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "10",
+			"casting_time": "Zeremonie (mehrere Stunden)",
+			"duration": "Instant",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Religious Rank"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 2
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Religion*"
+						},
+						"level": {
+							"compare": "at_least"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Clerical Investment"
+						},
+						"level": {
+							"compare": "at_least"
+						}
+					}
+				]
+			}
+		}
+	]
+}

--- a/Leif/DSA_Skills.skl
+++ b/Leif/DSA_Skills.skl
@@ -3,19 +3,6 @@
 	"version": 4,
 	"rows": [
 		{
-			"id": "394acc2a-7d11-4528-9bcc-fa8693698ac4",
-			"type": "skill",
-			"name": "Magie/E",
-			"difficulty": "mb/e",
-			"points": 1,
-			"defaults": [
-				{
-					"type": "mb",
-					"modifier": 1
-				}
-			]
-		},
-		{
 			"id": "1c2512c3-b48e-4c85-8bb1-1a879911e0e6",
 			"type": "skill",
 			"name": "Parkour",

--- a/Leif/DSA_Spells.spl
+++ b/Leif/DSA_Spells.spl
@@ -1,0 +1,25 @@
+{
+	"type": "spell_list",
+	"version": 4,
+	"rows": [
+		{
+			"id": "c7d80356-c1e8-469d-91e2-03b33d946640",
+			"type": "spell",
+			"name": "Flim Flam Funkel",
+			"reference": "LC87",
+			"tags": [
+				"Magic"
+			],
+			"difficulty": "mb/e",
+			"college": [
+				"Umwelt"
+			],
+			"power_source": "Arcane",
+			"casting_cost": "1",
+			"maintenance_cost": "1 pro SR",
+			"casting_time": "1 sec",
+			"duration": "Instant",
+			"points": 1
+		}
+	]
+}


### PR DESCRIPTION
For the dsa liturgy system gcs spell lack modifiers (primary liturgies are easier to perform and cost less).

We have to check if Religion* or Religion Zwölfgötter* oder something like that works as prerequisits for the liturgies. 

We need more difficulty levels, a litrugy of rank 4 already gets a -6 to the base value (up to -14 at rank 8)!

Our own attributes (wb, mb) do are not in the drop down list of the gui?